### PR TITLE
Adjust spacing and USP card styles

### DIFF
--- a/components/MyValues.tsx
+++ b/components/MyValues.tsx
@@ -22,7 +22,7 @@ const cardVariants = {
 
 export default function MyValues() {
 	return (
-		<section className="container my-12">
+		<section className="container py-20">
 			<h2 className="text-center text-slate-700 dark:text-slate-300">Mijn waarden</h2>
 			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mt-12">
 				<motion.div

--- a/components/homepage/usps.tsx
+++ b/components/homepage/usps.tsx
@@ -88,10 +88,10 @@ export default function USPS() {
                         "
                     >
                         <div className="flex items-center gap-4">
-                            <div className="p-4 bg-white shadow-md dark:bg-slate-800 rounded-full">
+                            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-white shadow-md dark:bg-slate-800">
                                 <reason.icon className="text-2xl text-primary" />
                             </div>
-                            <h3 className="text-lg text-slate-700 dark:text-slate-200 font-semibold">
+                            <h3 className="m-0 text-lg font-semibold leading-tight text-slate-700 dark:text-slate-200">
                                 {reason.title}
                             </h3>
                         </div>


### PR DESCRIPTION
Increase vertical spacing for the MyValues section (replace my-12 with py-20). Refine USP card layout: replace padding-based icon wrapper with a fixed 14x14 centered flex circle (preventing shrink), and tighten heading spacing by resetting margin and adding leading-tight. Changes in components/MyValues.tsx and components/homepage/usps.tsx.