### PR TITLE
Enforce tight line-height and tweak header/link styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -26,17 +26,17 @@
 
 @layer base {
     h1 {
-        @apply md:text-5xl text-4xl leading-tight font-bold text-transparent bg-clip-text bg-gradient-primary;
+        @apply md:text-5xl text-4xl !leading-tight font-bold text-transparent bg-clip-text bg-gradient-primary;
         -webkit-text-fill-color: transparent;
     }
     h2 {
-      @apply md:text-4xl text-3xl font-semibold;
+      @apply md:text-4xl text-3xl !leading-tight font-semibold;
     }
     h3{
-        @apply text-2xl font-semibold;
+        @apply text-2xl !leading-tight font-semibold;
     }
     h4{
-        @apply text-xl font-semibold;
+        @apply text-xl !leading-tight font-semibold;
     }
     .blog h2, h3, h4, h5, h5{
         @apply mt-6 mb-2;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -83,7 +83,7 @@ export default async function HomePage() {
                         </span>
                         <span>Beschikbaar voor {availableMonth}</span>
                     </p>
-                    <h1 className="max-w-4xl text-center mb-6 leading-tight md:leading-snug">
+                    <h1 className="max-w-4xl text-center mb-6 !leading-tight md:leading-snug md:text-4xl lg:text-5xl">
                         Freelance developer voor websites, Shopify en doorontwikkeling
                     </h1>
                     <p className="text-center mb-8 md:mb-0 md:text-lg text-gray-700 dark:text-gray-400">
@@ -105,7 +105,7 @@ export default async function HomePage() {
                     <Link
                         href="#services"
                         aria-label="Scroll naar de volgende sectie"
-                        className="absolute bottom-8 left-1/2 inline-flex h-12 w-12 -translate-x-1/2 items-center justify-center rounded-full border border-primary/15 bg-white/70 text-primary shadow-sm backdrop-blur-sm transition hover:bg-white hover:text-slate-900 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary/40 dark:bg-slate-900/65 dark:text-slate-100 dark:hover:bg-slate-900 animate-[bounce_2.4s_ease-in-out_infinite]"
+                        className="absolute inset-x-0 bottom-8 mx-auto inline-flex h-12 w-12 items-center justify-center rounded-full border border-primary/15 bg-white/70 text-primary shadow-sm backdrop-blur-sm transition hover:bg-white hover:text-slate-900 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary/40 dark:bg-slate-900/65 dark:text-slate-100 dark:hover:bg-slate-900 animate-[bounce_2.4s_ease-in-out_infinite]"
                     >
                         <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                             <path d="m6 9 6 6 6-6"></path>


### PR DESCRIPTION
Add !leading-tight to h1–h4 in globals.css to force a compact line-height across headings. Update HomePage h1 to include explicit responsive sizes (md:text-4xl, lg:text-5xl) and !leading-tight. Change the scroll Link centering to use inset-x-0 + mx-auto instead of left-1/2 with translate, improving horizontal centering/responsiveness while keeping existing styles and animation.